### PR TITLE
fix removing too many html content

### DIFF
--- a/dist/dmhy-bangumi-index.user.js
+++ b/dist/dmhy-bangumi-index.user.js
@@ -693,7 +693,7 @@
 
   const $$ = (s) => Array.from(document.querySelectorAll(s));
 
-  for (const adEl of $$('[id*="1280"]')) {
+  for (const adEl of $$('[id*="jmd"]')) {
     adEl.remove();
   }
 


### PR DESCRIPTION
突然發現我的花園全部的欄位都消失，發現花園改了html的位置，原先的寫法會把表列全部刪除。
做了簡單修正，只移除不更新的番表
（廣告另外用 adguard 來做掉）